### PR TITLE
Representational similarity

### DIFF
--- a/agents/CAHMM.py
+++ b/agents/CAHMM.py
@@ -398,7 +398,7 @@ class CAHMM:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),

--- a/agents/CAHMM.py
+++ b/agents/CAHMM.py
@@ -392,13 +392,13 @@ class CAHMM:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),
@@ -416,7 +416,7 @@ class CAHMM:
             "discount_factor": checkpoint["discount_factor"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "discriminator_threshold": checkpoint["discriminator_threshold"],
             "n_actions": checkpoint["n_actions"]

--- a/agents/CHMM.py
+++ b/agents/CHMM.py
@@ -342,7 +342,7 @@ class CHMM:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),

--- a/agents/CHMM.py
+++ b/agents/CHMM.py
@@ -327,13 +327,13 @@ class CHMM:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),
@@ -348,7 +348,7 @@ class CHMM:
             "beta_starting_step": checkpoint["beta_starting_step"],
             "beta_rate": checkpoint["beta_rate"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/CHMM.py
+++ b/agents/CHMM.py
@@ -272,6 +272,15 @@ class CHMM:
 
         return vfe_loss
 
+    def predict(self, obs):
+        """
+        Do one forward pass using given observation.
+        :return: the outputs of the encoder and critic model
+        """
+        mean_hat_t, log_var_hat_t = self.encoder(obs)
+        critic_pred = self.critic(mean_hat_t)
+        return mean_hat_t, log_var_hat_t, critic_pred
+
     def synchronize_target(self):
         """
         Synchronize the target with the critic.

--- a/agents/CHMM_2LS.py
+++ b/agents/CHMM_2LS.py
@@ -318,7 +318,7 @@ class CHMM_2LS:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder_2ls(checkpoint, training_mode),

--- a/agents/CHMM_2LS.py
+++ b/agents/CHMM_2LS.py
@@ -312,13 +312,13 @@ class CHMM_2LS:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder_2ls(checkpoint, training_mode),
@@ -331,7 +331,7 @@ class CHMM_2LS:
             "beta": checkpoint["beta"],
             "phi": checkpoint["phi"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/CHMM_C2LS.py
+++ b/agents/CHMM_C2LS.py
@@ -328,7 +328,7 @@ class CHMM_C2LS:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder_2ls(checkpoint, training_mode),

--- a/agents/CHMM_C2LS.py
+++ b/agents/CHMM_C2LS.py
@@ -322,13 +322,13 @@ class CHMM_C2LS:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder_2ls(checkpoint, training_mode),
@@ -341,7 +341,7 @@ class CHMM_C2LS:
             "beta": checkpoint["beta"],
             "phi": checkpoint["phi"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/CHMM_CN2LS.py
+++ b/agents/CHMM_CN2LS.py
@@ -336,13 +336,13 @@ class CHMM_CN2LS:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder_2ls(checkpoint, training_mode),
@@ -355,7 +355,7 @@ class CHMM_CN2LS:
             "beta": checkpoint["beta"],
             "phi": checkpoint["phi"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/CHMM_CN2LS.py
+++ b/agents/CHMM_CN2LS.py
@@ -342,7 +342,7 @@ class CHMM_CN2LS:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder_2ls(checkpoint, training_mode),

--- a/agents/CHMM_TS.py
+++ b/agents/CHMM_TS.py
@@ -393,10 +393,10 @@ class CHMM_TS:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
+        :param tb_dir: the hydra configuration.
         :param checkpoint: the chechpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
         :return: a dictionary containing the contrutor's parameters.
@@ -415,7 +415,7 @@ class CHMM_TS:
             "beta_starting_step": checkpoint["beta_starting_step"],
             "beta_rate": checkpoint["beta_rate"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/CHMM_TS.py
+++ b/agents/CHMM_TS.py
@@ -398,7 +398,7 @@ class CHMM_TS:
         :param tb_dir: the hydra configuration.
         :param checkpoint: the chechpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),

--- a/agents/Critic.py
+++ b/agents/Critic.py
@@ -228,7 +228,7 @@ class Critic:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "critic": Checkpoint.load_critic(checkpoint, training_mode),

--- a/agents/Critic.py
+++ b/agents/Critic.py
@@ -222,19 +222,19 @@ class Critic:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "critic": Checkpoint.load_critic(checkpoint, training_mode),
             "efe_lr": checkpoint["efe_lr"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "action_selection": Checkpoint.load_object_from_dictionary(checkpoint, "action_selection"),
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/CriticFixedHMM.py
+++ b/agents/CriticFixedHMM.py
@@ -319,7 +319,7 @@ class CriticFixedHMM:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),

--- a/agents/CriticFixedHMM.py
+++ b/agents/CriticFixedHMM.py
@@ -313,13 +313,13 @@ class CriticFixedHMM:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),
@@ -334,7 +334,7 @@ class CriticFixedHMM:
             "beta_starting_step": checkpoint["beta_starting_step"],
             "beta_rate": checkpoint["beta_rate"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/DAI.py
+++ b/agents/DAI.py
@@ -286,6 +286,16 @@ class DAI:
         self.target = copy.deepcopy(self.critic)
         self.target.eval()
 
+    def predict(self, obs):
+        """
+        Do one forward pass using given observation.
+        :return: the outputs of the encoder, policy and critic
+        """
+        mean_hat_t, log_var_hat_t = self.encoder(obs)
+        policy_pred = self.policy(mean_hat_t)
+        critic_pred = self.critic(mean_hat_t)
+        return mean_hat_t, critic_pred, policy_pred
+
     def save(self, config):
         """
         Create a checkpoint file allowing the agent to be reloaded later
@@ -336,10 +346,10 @@ class DAI:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
+        :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the chechpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
         :return: a dictionary containing the contrutor's parameters.
@@ -358,7 +368,7 @@ class DAI:
             "beta_starting_step": checkpoint["beta_starting_step"],
             "beta_rate": checkpoint["beta_rate"],
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "g_value": checkpoint["g_value"],
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],

--- a/agents/DAIMC.py
+++ b/agents/DAIMC.py
@@ -539,7 +539,7 @@ class DAIMC:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),

--- a/agents/DAIMC.py
+++ b/agents/DAIMC.py
@@ -533,13 +533,13 @@ class DAIMC:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),
@@ -565,7 +565,7 @@ class DAIMC:
             "efe_deepness": checkpoint["efe_deepness"],
             "efe_n_samples": checkpoint["efe_n_samples"],
             "queue_capacity": checkpoint["queue_capacity"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "steps_done": checkpoint["steps_done"],
         }
 

--- a/agents/DQN.py
+++ b/agents/DQN.py
@@ -207,20 +207,20 @@ class DQN:
     #
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "policy": Checkpoint.load_policy(checkpoint, training_mode),
             "lr": checkpoint["lr"],
             "action_selection": Checkpoint.load_object_from_dictionary(checkpoint, "action_selection"),
             "discount_factor": checkpoint["discount_factor"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
             "queue_capacity": checkpoint["queue_capacity"],
             "n_steps_between_synchro": checkpoint["n_steps_between_synchro"],
             "steps_done": checkpoint["steps_done"],

--- a/agents/DQN.py
+++ b/agents/DQN.py
@@ -202,6 +202,13 @@ class DQN:
 
         return loss
 
+    def predict(self, obs):
+        """
+        Do one forward pass using given observation.
+        :return: the outputs of the policy network
+        """
+        return self.policy(obs)
+
     #
     # Saving and reloading the model.
     #

--- a/agents/DQN.py
+++ b/agents/DQN.py
@@ -220,7 +220,7 @@ class DQN:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "policy": Checkpoint.load_policy(checkpoint, training_mode),

--- a/agents/HMM.py
+++ b/agents/HMM.py
@@ -221,13 +221,13 @@ class HMM:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),
@@ -241,5 +241,5 @@ class HMM:
             "beta_rate": checkpoint["beta_rate"],
             "steps_done": checkpoint["steps_done"],
             "queue_capacity": checkpoint["queue_capacity"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
         }

--- a/agents/HMM.py
+++ b/agents/HMM.py
@@ -183,6 +183,13 @@ class HMM:
 
         return vfe_loss
 
+    def predict(self, obs):
+        """
+        Do one forward pass using given observation.
+        :return: the outputs of the encoder
+        """
+        return self.encoder(obs)
+
     def save(self, config):
         """
         Create a checkpoint file allowing the agent to be reloaded later.

--- a/agents/HMM.py
+++ b/agents/HMM.py
@@ -234,7 +234,7 @@ class HMM:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),

--- a/agents/VAE.py
+++ b/agents/VAE.py
@@ -178,6 +178,13 @@ class VAE:
 
         return vfe_loss
 
+    def predict(self, obs):
+        """
+        Do one forward pass using given observation.
+        :return: the outputs of the encoder
+        """
+        return self.encoder(obs)
+
     def save(self, config):
         """
         Create a checkpoint file allowing the agent to be reloaded later

--- a/agents/VAE.py
+++ b/agents/VAE.py
@@ -226,7 +226,7 @@ class VAE:
         :param tb_dir: the path of tensorboard directory.
         :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contructor's parameters.
+        :return: a dictionary containing the constructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),

--- a/agents/VAE.py
+++ b/agents/VAE.py
@@ -213,13 +213,13 @@ class VAE:
         }, checkpoint_file)
 
     @staticmethod
-    def load_constructor_parameters(config, checkpoint, training_mode=True):
+    def load_constructor_parameters(tb_dir, checkpoint, training_mode=True):
         """
         Load the constructor parameters from a checkpoint.
-        :param config: the hydra configuration.
-        :param checkpoint: the chechpoint from which to load the parameters.
+        :param tb_dir: the path of tensorboard directory.
+        :param checkpoint: the checkpoint from which to load the parameters.
         :param training_mode: True if the agent is being loaded for training, False otherwise.
-        :return: a dictionary containing the contrutor's parameters.
+        :return: a dictionary containing the contructor's parameters.
         """
         return {
             "encoder": Checkpoint.load_encoder(checkpoint, training_mode),
@@ -232,5 +232,5 @@ class VAE:
             "beta_rate": checkpoint["beta_rate"],
             "steps_done": checkpoint["steps_done"],
             "queue_capacity": checkpoint["queue_capacity"],
-            "tensorboard_dir": config["agent"]["tensorboard_dir"],
+            "tensorboard_dir": tb_dir,
         }

--- a/agents/save/Checkpoint.py
+++ b/agents/save/Checkpoint.py
@@ -11,10 +11,10 @@ import torch
 #
 class Checkpoint:
 
-    def __init__(self, config, file):
+    def __init__(self, tb_dir, file):
         """
         Construct the checkpoint from the checkpoint file.
-        :param config: the hydra configuration.
+        :param tb_dir: the path of tensorboard directory.
         :param file: the checkpoint file.
         """
 
@@ -27,8 +27,8 @@ class Checkpoint:
         # Load checkpoint from path.
         self.checkpoint = torch.load(file, map_location=Device.get())
 
-        # Store the configuration
-        self.config = config
+        # Store the pth of the tensoboard directory
+        self.tb_dir = tb_dir
 
     def exists(self):
         """
@@ -53,7 +53,7 @@ class Checkpoint:
         agent_class = getattr(agent_module, self.checkpoint["agent_class"])
 
         # Load the parameters of the constructor from the checkpoint.
-        param = agent_class.load_constructor_parameters(self.config, self.checkpoint, training_mode)
+        param = agent_class.load_constructor_parameters(self.tb_dir, self.checkpoint, training_mode)
 
         # Instantiate the agent.
         return agent_class(**param)

--- a/agents/save/Checkpoint.py
+++ b/agents/save/Checkpoint.py
@@ -27,7 +27,7 @@ class Checkpoint:
         # Load checkpoint from path.
         self.checkpoint = torch.load(file, map_location=Device.get())
 
-        # Store the pth of the tensoboard directory
+        # Store the path of the tensoboard directory
         self.tb_dir = tb_dir
 
     def exists(self):

--- a/compute_similarity.py
+++ b/compute_similarity.py
@@ -73,7 +73,7 @@ def compute_sim(cfg):
     env = DefaultWrappers.apply(env, cfg.images.shape)
 
     # Sample a batch of experiences.
-    samples, actions, rewards, done, next_obs = get_batch(batch_size=5000, env=env)  # TODO pick what you need
+    samples, actions, rewards, done, next_obs = get_batch(batch_size=5000, env=env)
 
     m1 = Checkpoint(cfg.a1_tensorboard_dir, cfg.a1_path).load_model()
     m2 = Checkpoint(cfg.a2_tensorboard_dir, cfg.a2_path).load_model()

--- a/compute_similarity.py
+++ b/compute_similarity.py
@@ -42,7 +42,7 @@ def plot(res, save_path):
     # We also drop activations from dropout and reshape layers as they are not very informative.
     logger.debug("Dataframe before pre-processing: {}".format(res))
     cols_to_keep = {"Encoder_2": "Encoder_1", "Encoder_4": "Encoder_2", "Encoder_6": "Encoder_3",
-                    "Encoder_8": "Encoder_4", "Encoder_11": "Encoder_4", "Encoder_12": "Encoder_6",
+                    "Encoder_8": "Encoder_4", "Encoder_11": "Encoder_5", "Encoder_12": "Encoder_6",
                     "Encoder_13": "Encoder_7", "Critic_2": "Critic_1", "Critic_4": "Critic_2", "Critic_6": "Critic_3",
                     "Critic_7": "Critic_4", "Policy_2": "Policy_1", "Policy_4": "Policy_2", "Policy_6": "Policy_3",
                     "Policy_7": "Policy_4"}

--- a/compute_similarity.py
+++ b/compute_similarity.py
@@ -1,0 +1,51 @@
+import logging
+import hydra
+from omegaconf import OmegaConf
+from representational_similarity.cka import CKA
+from representational_similarity.utils import get_activations, prepare_activations, save_figure
+import pandas as pd
+import seaborn as sns
+logger = logging.getLogger("similarity_metric")
+
+
+def compute_similarity_metric(model1, model2, samples, save_path):
+    logger.info("Instantiating CKA...")
+    metric = CKA()
+    acts1 = get_activations(samples, model1)
+    acts2 = get_activations(samples, model2)
+    logger.info("Preparing layer activations...")
+    f = lambda x: metric.center(prepare_activations(x))
+    acts1 = {k: f(v) for k, v in acts1.items()}
+    acts2 = {k: f(v) for k, v in acts2.items()}
+    res = {}
+    for l1, act1 in acts1.items():
+        res[l1] = {}
+        for l2, act2 in acts2.items():
+            logger.info("Computing similarity of {} and {}".format(l1, l2))
+            res[l1][l2] = float(metric(act1, act2))
+    res = pd.DataFrame(res).T
+    # Save csv with m1 layers as header, m2 layers as indexes
+    res = res.rename_axis("m1", axis="columns")
+    res = res.rename_axis("m2")
+    sns.heatmap(res, vmin=0, vmax=1, annot_kws={"fontsize": 13})
+    save_figure("{}.pdf".format(save_path))
+    res.to_csv("{}.tsv".format(save_path), sep="\t")
+
+
+@hydra.main(config_path="config", config_name="similarity")
+def compute_sim(cfg):
+    logger.info("Experiment config:\n{}".format(OmegaConf.to_yaml(cfg)))
+    save_path = "CKA_{}_{}.tsv".format(cfg.agent1_name, cfg.agent2_name)
+    # TODO: Check how to randomly sample cfg.n_samples from a given dataset
+    # This would be equivalent to vae_ld's following code
+    # dataset = instantiate(cfg.dataset)
+    # samples = dataset.sample(cfg.n_samples, random_state, unique=True)[1]
+    samples = None
+    # TODO: Check how to load the models
+    m1 = None
+    m2 = None
+    compute_similarity_metric(m1, m2, samples, save_path)
+
+
+if __name__ == "__main__":
+    compute_sim()

--- a/config/similarity.yaml
+++ b/config/similarity.yaml
@@ -2,24 +2,28 @@ n_samples: 10000
 
 defaults:
   - env: dSprites
+  - _self_
 
 images:
   shape: ${tuple:1,64,64}
 
-agent1_name: dqn
-agent1_seed: 0
-agent2_name: daimc
-agent2_seed: 0
+a1_name: dqn
+a1_seed: 1
+a1_path: ${oc.env:DATA_DIRECTORY}/${env.name}/${a1_name}/${a1_seed}/model.pt
+a1_tensorboard_dir: ${oc.env:DATA_DIRECTORY}/runs/${a1_name}_${env.name}_${a1_seed}
 
-m1_path: ${oc.env:DATA_DIRECTORY}/${env.name}/${agent1_name}/${agent1_seed}/model.pt
-m2_path: ${oc.env:DATA_DIRECTORY}/${env.name}/${agent2_name}/${agent2_seed}/model.pt
+a2_name: vae
+a2_seed: 1
+a2_path: ${oc.env:DATA_DIRECTORY}/${env.name}/${a2_name}/${a2_seed}/model.pt
+a2_tensorboard_dir: ${oc.env:DATA_DIRECTORY}/runs/${a2_name}_${env.name}_${a2_seed}
+
 
 hydra:
   run:
-    dir: ${oc.env:DATA_DIRECTORY}/${env.name}/${hydra.job.name}/${agent1_name}/${agent1_seed}/${agent2_name}/${agent2_seed}
+    dir: ${oc.env:DATA_DIRECTORY}/${env.name}/${hydra.job.name}/${a1_name}/${a1_seed}/${a2_name}/${a2_seed}
   sweep:
-    dir: ${oc.env:DATA_DIRECTORY}/${env.name}/${hydra.job.name}/${agent1_name}/${agent1_seed}/${agent2_name}
-    subdir: ${agent2_seed}
+    dir: ${oc.env:DATA_DIRECTORY}/${env.name}/${hydra.job.name}/${a1_name}/${a1_seed}/${a2_name}
+    subdir: ${a2_seed}
   job:
     config:
       override_dirname:

--- a/config/similarity.yaml
+++ b/config/similarity.yaml
@@ -1,5 +1,11 @@
 n_samples: 10000
 
+defaults:
+  - env: dSprites
+
+images:
+  shape: ${tuple:1,64,64}
+
 agent1_name: dqn
 agent1_seed: 0
 agent2_name: daimc

--- a/config/similarity.yaml
+++ b/config/similarity.yaml
@@ -1,0 +1,21 @@
+n_samples: 10000
+
+agent1_name: dqn
+agent1_seed: 0
+agent2_name: daimc
+agent2_seed: 0
+
+m1_path: ${oc.env:DATA_DIRECTORY}/${env.name}/${agent1_name}/${agent1_seed}/model.pt
+m2_path: ${oc.env:DATA_DIRECTORY}/${env.name}/${agent2_name}/${agent2_seed}/model.pt
+
+hydra:
+  run:
+    dir: ${oc.env:DATA_DIRECTORY}/${env.name}/${hydra.job.name}/${agent1_name}/${agent1_seed}/${agent2_name}/${agent2_seed}
+  sweep:
+    dir: ${oc.env:DATA_DIRECTORY}/${env.name}/${hydra.job.name}/${agent1_name}/${agent1_seed}/${agent2_name}
+    subdir: ${agent2_seed}
+  job:
+    config:
+      override_dirname:
+        kv_sep: _
+        item_sep: /

--- a/daimc_training.py
+++ b/daimc_training.py
@@ -66,7 +66,7 @@ def train(config):
         envs.append(env)
 
     # Create the agent.
-    archive = Checkpoint(config, config["checkpoint"]["file"])
+    archive = Checkpoint(config["agent"]["tensorboard_dir"], config["checkpoint"]["file"])
     agent = archive.load_model() if archive.exists() else instantiate(config["agent"])
 
     # Train the agent in the environment.

--- a/env_testing.py
+++ b/env_testing.py
@@ -27,7 +27,7 @@ def test(config):
     env = DefaultWrappers.apply(env, config["images"]["shape"])
 
     # Create the agent and train it.
-    archive = Checkpoint(config, config["checkpoint"]["file"])
+    archive = Checkpoint(config["agent"]["tensorboard_dir"], config["checkpoint"]["file"])
     agent = archive.load_model() if archive.exists() else instantiate(config["agent"])
     agent.test(env, config)
 

--- a/env_training.py
+++ b/env_training.py
@@ -27,7 +27,7 @@ def train(config):
     env = DefaultWrappers.apply(env, config["images"]["shape"])
 
     # Create the agent and train it.
-    archive = Checkpoint(config, config["checkpoint"]["file"])
+    archive = Checkpoint(config["agent"]["tensorboard_dir"], config["checkpoint"]["file"])
     agent = archive.load_model() if archive.exists() else instantiate(config["agent"])
     agent.train(env, config)
 

--- a/representational_similarity/__init__.py
+++ b/representational_similarity/__init__.py
@@ -1,0 +1,5 @@
+import logging
+
+FORMAT = '%(asctime)s:%(process)d:%(levelname)s::%(message)s'
+logging.basicConfig(format=FORMAT)
+logger = logging.getLogger("representational_similarity")

--- a/representational_similarity/cka.py
+++ b/representational_similarity/cka.py
@@ -1,0 +1,75 @@
+import numpy as np
+from representational_similarity import logger
+
+
+class CKA:
+    """ Compute the linear Centered Kernel Alignment (CKA).
+    Adapted from the demo code of Kornblith et al. [1]. from
+    https://colab.research.google.com/github/google-research/google-research/blob/master/representation_similarity/Demo.ipynb#scrollTo=MkucRi3yn7UJ_
+
+    :param str name: The name of the metric. Default "CKA".
+    :param bool debiased: If True, use the debiased implementation of CKA proposed by Székely et al. [2] instead of the
+    standard one. Default False.
+
+    .. [1] Kornblith, S., Norouzi, M., Lee, H., & Hinton, G. (2019, May). Similarity of neural network representations
+           revisited. In International Conference on Machine Learning (pp. 3519-3529). PMLR.
+    .. [2] Székely, G. J., & Rizzo, M. L. (2014). Partial distance correlation with methods for dissimilarities.
+           The Annals of Statistics, 42(6), 2382-2412.
+    """
+    def __init__(self, name="CKA", debiased=False):
+        self._debiased = debiased
+        self._name = name
+
+    @property
+    def debiased(self):
+        return self._debiased
+
+    @debiased.setter
+    def debiased(self, debiased):
+        self._debiased = debiased
+
+    @property
+    def name(self):
+        return self._name
+
+    def center(self, x):
+        """ Center the matrix `x` so that its mean is 0.
+        :param np.array x: The matrix to center
+        :return: The centered matrix.
+        :rtype: np.array
+        """
+        if self._debiased:
+            x = np.dot(x, x.T)
+            n = x.shape[0]
+            np.fill_diagonal(x, 0)
+            means = np.sum(x, 0, dtype=np.float64) / (n - 2)
+            means -= np.sum(means) / (2 * (n - 1))
+            x_centred = x - means[None, :]
+            x_centred -= means[:, None]
+            np.fill_diagonal(x_centred, 0)
+        else:
+            x_centred = x - np.mean(x, axis=0, keepdims=True)
+            x_centred = np.dot(x_centred, np.transpose(x_centred))
+        return x_centred
+
+    def cka(self, x, y):
+        """ Compute The CKA score between `x` and `y`. Both matrices are assumed to be centered and to contain the same
+        number of data examples `n`.
+
+        :param np.array x: A centered matrix of size (n, n)
+        :param np.array y: A centered matrix of size (n, n)
+        :return: A CKA score between 0 (not similar at all) and 1 (identical).
+        :rtype: float
+        """
+        # Note: this method assumes that kc and lc are the centered kernel values given by cka.center(cka.kernel(.))
+        # Compute tr(KcLc) = vec(kc)^T vec(lc), omitting the term (m-1)**2, which is canceled by CKA
+        hsic = np.dot(np.ravel(x), np.ravel(y))
+        normalization_x = np.linalg.norm(x)
+        normalization_y = np.linalg.norm(y)
+        cka = hsic / (normalization_x * normalization_y)
+        # Divide by the product of the Frobenius norms of kc and lc to get CKA
+        logger.debug("CKA = {} / ({} * {}) = {}".format(hsic, normalization_x, normalization_y, cka))
+        return cka
+
+    def __call__(self, x, y):
+        return self.cka(x, y)

--- a/representational_similarity/utils.py
+++ b/representational_similarity/utils.py
@@ -1,0 +1,63 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def get_activation(name, activation):
+    def hook(model, input, output):
+        activation[name] = output.detach()
+    return hook
+
+
+def get_activations(data, model):
+    """ Load a model and generate a dictionary of the activations obtained from `data`.
+    We assume that the activations of each layers are exposed.
+
+    :param np.array data: A (n_examples, n_features) data matrix
+    :param model: The model to use
+    :return: A tuple containing the loaded model, list of activations, and list of layer names.
+    """
+    activations = {}
+    hooks = []
+
+    # TODO: model.get_layers() needs to be updated to the correct pytorch equivalent
+    # Register forward hooks to get the activations of all the layers
+    for name, layer in model.get_layers():
+        hooks.append(layer.register_forward_hook(get_activation(name, activations)))
+
+    # Store the activations using the hooks during the forward pass
+    model(data)
+
+    # Remove the hooks
+    for hook in hooks:
+        hook.remove()
+
+    return activations
+
+
+def prepare_activations(x):
+    """ Flatten the activation values to get a 2D array and values very close to 0 (e.g., 1e-15) to 0.
+
+    :param x: A (n_example, n_features) matrix of activations
+    :return: A (n_example, n_features) tensor of activations. If len(n_features) was initially greater than 1,
+    n_features = np.prod(n_features).
+    """
+    if len(x.shape) > 2:
+        x = x.reshape(x.shape[0], np.prod(x.shape[1:]))
+    # Prevent very tiny values from causing underflow in similarity metrics later on
+    x[abs(x) < 1.e-7] = 0.
+    return x
+
+
+def save_figure(out_fname, dpi=300, tight=True):
+    """ Save a matplotlib figure in an `out_fname` file.
+
+    :param str out_fname: Name of the file used to save the figure.
+    :param int dpi: Number of dpi, Default 300.
+    :param bool tight: If True, use plt.tight_layout() before saving. Default True.
+    """
+    if tight is True:
+        plt.tight_layout()
+    plt.savefig(out_fname, dpi=dpi, transparent=True)
+    plt.clf()
+    plt.cla()
+    plt.close()

--- a/representational_similarity/utils.py
+++ b/representational_similarity/utils.py
@@ -77,7 +77,12 @@ def select_and_get_layers(model):
     if isinstance(model, CHMM.CHMM) or isinstance(model, DAI):
         curr_layers_info, _ = get_layers(list(model.critic.modules())[1], "Critic")
         layers_info += curr_layers_info
-    if isinstance(model, DQN.DQN) or isinstance(model, DAI):
+    if isinstance(model, DQN.DQN):
+        curr_layers_info, _ = get_layers(list(model.policy.modules())[-1], "Policy")
+        layers_info += curr_layers_info
+    # The policy is not the same for DAI so we change the module index
+    # It could be nice to uniformise the initialisation of the models architectures in the future.
+    if isinstance(model, DAI):
         curr_layers_info, _ = get_layers(list(model.policy.modules())[1], "Policy")
         layers_info += curr_layers_info
     logger.debug("Found layers {}".format(layers_info))

--- a/representational_similarity/utils.py
+++ b/representational_similarity/utils.py
@@ -75,10 +75,10 @@ def select_and_get_layers(model):
         curr_layers_info, _ = get_layers(list(model.encoder.modules())[-1], "Encoder")
         layers_info += curr_layers_info
     if isinstance(model, CHMM.CHMM) or isinstance(model, DAI):
-        curr_layers_info, _ = get_layers(list(model.critic.modules())[-1], "Critic")
+        curr_layers_info, _ = get_layers(list(model.critic.modules())[1], "Critic")
         layers_info += curr_layers_info
     if isinstance(model, DQN.DQN) or isinstance(model, DAI):
-        curr_layers_info, _ = get_layers(list(model.policy.modules())[-1], "Policy")
+        curr_layers_info, _ = get_layers(list(model.policy.modules())[1], "Policy")
         layers_info += curr_layers_info
     logger.debug("Found layers {}".format(layers_info))
     return layers_info

--- a/representational_similarity/utils.py
+++ b/representational_similarity/utils.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 from torch import nn
 
 from agents import DQN, CHMM
+from agents.DAI import DAI
 from agents.layers.DiagonalGaussian import DiagonalGaussian
 from representational_similarity import logger
 
@@ -70,14 +71,13 @@ def save_figure(out_fname, dpi=300, tight=True):
 
 def select_and_get_layers(model):
     layers_info = []
-    # TODO: update this part with DAI when DAI is implemented
     if not isinstance(model, DQN.DQN):
         curr_layers_info, _ = get_layers(list(model.encoder.modules())[-1], "Encoder")
         layers_info += curr_layers_info
-    if isinstance(model, CHMM.CHMM):  # or isinstance(model, DAI)
+    if isinstance(model, CHMM.CHMM) or isinstance(model, DAI):
         curr_layers_info, _ = get_layers(list(model.critic.modules())[-1], "Critic")
         layers_info += curr_layers_info
-    if isinstance(model, DQN.DQN):  # or isinstance(model, DAI)
+    if isinstance(model, DQN.DQN) or isinstance(model, DAI):
         curr_layers_info, _ = get_layers(list(model.policy.modules())[-1], "Policy")
         layers_info += curr_layers_info
     logger.debug("Found layers {}".format(layers_info))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ttkthemes
 hydra
 pandas~=1.4.2
 seaborn~=0.11.2
+tensorboard

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ future~=0.18.2
 omegaconf~=2.1.1
 ttkthemes
 hydra
+pandas~=1.4.2
+seaborn~=0.11.2


### PR DESCRIPTION
This branch implement CKA for DQN, VAE, HMM, CHMM, and DAI agents.
This will compute CKA scores for each pairs of layer activations and save the result as a tsv file. 
A heatmap of the results taken after each activation function (when they exists) is also plotted and saved as pdf.

One can compute the representational similarity using 
`python compute_similarity.py a1_name=<agent_1_name> a1_seed=<agent_1_seed> a2_name=<agent_2_name> a2_seed=<agent_2_seed>`.
The default values are:
 `dqn` for `a1_name`
 `vae` for `a2_name`
`1` for  `a1_seed` and `a2_seed`.

Note that for now, this only works for the default architectures of the given models. We may need to standardise the way model architectures are initialised if this needs to be applied on other architectures.